### PR TITLE
Adjusts project files to make it easier to rebuild for different versions of JBoss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<!-- JBoss dependency versions -->
 		<version.org.jboss.as.parent>7.5.21.Final-redhat-1</version.org.jboss.as.parent>   <!-- JBoss EAP 6.4.21 -->
 
-		<version.bc-fips>1.0.0</version.bc-fips>
+		<version.bc-fips>1.0.1</version.bc-fips>
 
 		<version.maven-compiler-plugin>3.6.1</version.maven-compiler-plugin>
 		<version.maven-jar-plugin>3.0.2</version.maven-jar-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 	~
 	~ JBoss, Home of Professional Open Source.
@@ -29,7 +29,7 @@
 
 	<groupId>org.jboss.security.fips</groupId>
 	<artifactId>fips-compliant-vault</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 	<name>FIPS Compliant Vault</name>
 	<description>FIPS compliant custom password vault for EAP.</description>
@@ -55,51 +55,55 @@
 		<maven.compiler.target>1.6</maven.compiler.target>
 
 		<!-- JBoss dependency versions -->
+		<version.org.jboss.as.parent>7.5.21.Final-redhat-1</version.org.jboss.as.parent>   <!-- JBoss EAP 6.4.21 -->
 
-		<version.jboss.logging-processor>1.1.0.Final-redhat-1</version.jboss.logging-processor>
-		<version.jboss.logging>3.1.4.GA-redhat-2</version.jboss.logging>
-		<version.jboss.modules>1.3.7.Final-redhat-1</version.jboss.modules>
-		<version.commons-cli>1.2.0.redhat-8</version.commons-cli>
-		<version.picketbox>4.1.3.Final-redhat-1</version.picketbox>
 		<version.bc-fips>1.0.0</version.bc-fips>
+
 		<version.maven-compiler-plugin>3.6.1</version.maven-compiler-plugin>
 		<version.maven-jar-plugin>3.0.2</version.maven-jar-plugin>
 		<version.maven-assembly-plugin>3.0.0</version.maven-assembly-plugin>
 
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.jboss.as</groupId>
+				<artifactId>jboss-as-parent</artifactId>
+				<type>pom</type>
+				<version>${version.org.jboss.as.parent}</version>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.logging</groupId>
 			<artifactId>jboss-logging-processor</artifactId>
-			<version>${version.jboss.logging-processor}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jboss.logging</groupId>
 			<artifactId>jboss-logging</artifactId>
-			<version>${version.jboss.logging}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jboss.modules</groupId>
 			<artifactId>jboss-modules</artifactId>
-			<version>${version.jboss.modules}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
-			<version>${version.commons-cli}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.picketbox</groupId>
 			<artifactId>picketbox</artifactId>
-			<version>${version.picketbox}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <assembly>
   <id>dist</id>
   <includeBaseDirectory>false</includeBaseDirectory>
@@ -25,19 +26,19 @@
       <fileMode>0755</fileMode>
     </fileSet>
   </fileSets>
-      <files>
-        <file>
-          <source>target/classes/vault-module.xml</source>
-          <outputDirectory>modules/org/jboss/security/fips/main</outputDirectory>
-          <destName>module.xml</destName>
-        </file>
-        <file>
-          <source>target/classes/tool-module.xml</source>
-          <outputDirectory>modules/org/jboss/security/fips/vault-tool/main</outputDirectory>
-          <destName>module.xml</destName>
-        </file>
-      </files>
-<dependencySets>
+  <files>
+    <file>
+      <source>target/classes/vault-module.xml</source>
+      <outputDirectory>modules/org/jboss/security/fips/main</outputDirectory>
+      <destName>module.xml</destName>
+    </file>
+    <file>
+      <source>target/classes/tool-module.xml</source>
+      <outputDirectory>modules/org/jboss/security/fips/vault-tool/main</outputDirectory>
+      <destName>module.xml</destName>
+    </file>
+  </files>
+  <dependencySets>
     <dependencySet>
       <outputDirectory>modules/org/jboss/security/fips/main</outputDirectory>
       <includes>
@@ -45,5 +46,5 @@
         <include>org.bouncycastle:bc-fips</include>
       </includes>
     </dependencySet>
-</dependencySets>
+  </dependencySets>
 </assembly>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -42,7 +42,6 @@
     <dependencySet>
       <outputDirectory>modules/org/jboss/security/fips/main</outputDirectory>
       <includes>
-        <include>commons-cli:commons-cli</include>
         <include>org.bouncycastle:bc-fips</include>
       </includes>
     </dependencySet>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -31,6 +31,7 @@
       <source>target/classes/vault-module.xml</source>
       <outputDirectory>modules/org/jboss/security/fips/main</outputDirectory>
       <destName>module.xml</destName>
+      <filtered>true</filtered>
     </file>
     <file>
       <source>target/classes/tool-module.xml</source>

--- a/src/main/resources/vault-module.xml
+++ b/src/main/resources/vault-module.xml
@@ -24,8 +24,8 @@
 
 <module xmlns="urn:jboss:module:1.1" name="org.jboss.security.fips">
     <resources>
-        <resource-root path="bc-fips-1.0.0.jar"/>
-        <resource-root path="fips-compliant-vault-1.0.1.jar"/>
+        <resource-root path="bc-fips-${version.bc-fips}.jar"/>
+        <resource-root path="fips-compliant-vault-${project.version}.jar"/>
     </resources>
 
     <dependencies>

--- a/src/main/resources/vault-module.xml
+++ b/src/main/resources/vault-module.xml
@@ -26,7 +26,7 @@
     <resources>
         <resource-root path="bc-fips-1.0.0.jar"/>
         <resource-root path="commons-cli-1.2.0.redhat-8.jar"/>
-        <resource-root path="fips-compliant-vault-1.0.0.jar"/>
+        <resource-root path="fips-compliant-vault-1.0.1.jar"/>
     </resources>
 
     <dependencies>

--- a/src/main/resources/vault-module.xml
+++ b/src/main/resources/vault-module.xml
@@ -25,12 +25,12 @@
 <module xmlns="urn:jboss:module:1.1" name="org.jboss.security.fips">
     <resources>
         <resource-root path="bc-fips-1.0.0.jar"/>
-        <resource-root path="commons-cli-1.2.0.redhat-8.jar"/>
         <resource-root path="fips-compliant-vault-1.0.1.jar"/>
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="org.apache.commons.cli"/>
         <module name="org.jboss.logging"/>
         <module name="org.picketbox"/>
         <module name="sun.jdk"/>


### PR DESCRIPTION
The three main changes are:

1. Imports org.joss.as:jboss-as-parent in order to get the exact versions of dependencies for any specific version of JBoss.
   * Specific versions of dependencies deleted as a consequence

1. Makes the vault module depend on org.apache.commons.cli instead of adding commons-cli.jar as a module resource.
   * I don't know the original reason to have commons-cli as a resource instead of as a dependency. If this is inadequate, please tell.

1. Uses resource filtering to avoid having version numbers written directly into vault-module.xml. 
   * This way, we only have to update versions in the base POM.

Additionally, the version of bc-fips is updated to 1.0.1, but this is not related to the other, more structural, changes. If this is inadequate, please discard.

These changes compile ok at least with:
* jboss-as-parent 7.5.0.Final-redhat-18 (JBoss EAP 6.4.0)
* jboss-as-parent 7.5.21.Final-redhat-1 (JBoss EAP 6.4.21)

It then becomes very easy to adapt to:
* wildfly-parent 8.2.1.Final (WildFly 8.2.1.Final)

The changes have been tested in runtime only with WildFly 8.2.1.Final.